### PR TITLE
fix: resolve problem with null request on the first load

### DIFF
--- a/src/react-image-zooom.js
+++ b/src/react-image-zooom.js
@@ -191,7 +191,7 @@ function ImageZoom({
         id={id}
         className={[figureClass, figureZoomed, className].join(" ")}
         style={{
-          backgroundImage: `url( ${zoomed === '0' ? imgData : ''} )`,
+          backgroundImage: `url( ${zoomed === '0' && imgData ? imgData : ''} )`,
           backgroundSize: zoom + "%",
           backgroundPosition: position,
         }}
@@ -202,14 +202,14 @@ function ImageZoom({
         onTouchMove={handleMove}
         onTouchEnd={handleLeave}
       >
-        <Img
+        {imgData && <Img
           id="imageZoom"
           src={imgData}
           alt={alt}
           style={{ opacity: zoomed }}
           width={width}
           height={height}
-        />
+        />}
       </Figure>
     );
   }


### PR DESCRIPTION
I'm pretty sure the problem with the null request is connected to a missing guard. 

When react renders your component the imgData is null. According to docs on the first render, React builds your component then injects it into the DOM, and only then runs useEffects. 

In our case:
1) We have the state imgData with the value null.
2) React build component and inject this
```
<Img
          id="imageZoom"
          src={imgData} // Keep in mind this state is still null
          alt={alt}
          style={{ opacity: zoomed }}
          width={width}
          height={height}
        />
```
to DOM.
3) Browser requests the image with src null
4) Only then the React runs UseEffect with the correct image src.


My changes should prevent this null request