### PR TITLE
Fixes bug where scroll becomes locked on mobile after touchmove event

### DIFF
--- a/src/react-image-zooom.js
+++ b/src/react-image-zooom.js
@@ -152,9 +152,8 @@ function ImageZoom({
       position: "50% 50%",
       isOverflowHidden: false
     }));
-    return () => {
-      document.body.style.overflow = "initial";
-    };
+
+    document.body.style.overflow = "auto";  
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## Issue:
- Scroll would become locked on mobile devices after touching and moving an ImageZoom component. 
- handleLeave was incorrectly attempting to restore scrolling to the body via clean up function with useCallback. However, react does not provide clean up functions within useCallbacks and hence scrolling was never being restored. 

## Fix:
- Removes the clean up function and places the relevant css directly within the useCallback, after the setState function. 
- This allows the body's overflow to be set to auto upon onMouseLeave and onTouchEnd.