### PR TITLE
feat: add classNames and onZoomChange props to ImageZoom component

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,12 @@ This component accepts the following attributes:
 | alt       | "This is an imageZoom image" |    false |
 | width     |            "100%"            |    false |
 | height    |            "auto"            |    false |
+| classNames |          Null               | false |
+| onZoomChange |        Null                | false |
+
+`classNames` accepts an object with optional `wrapper` and `image` string properties to apply custom classes to the wrapper and image elements. 
+
+`onZoomChange` is an optional callback `(isZoomed: boolean) => void` invoked whenever the zoomed state changes.
 
 As you can see above, it is very similar to the standard `<img />` tag, now let's look at a more advanced example of a gallery using the component ([View on CodePen](https://codepen.io/MarioDesigns/pen/9a673471b4b45d2b0cf51f1c3f7e8429)).
 

--- a/src/react-image-zooom.tsx
+++ b/src/react-image-zooom.tsx
@@ -95,8 +95,13 @@ interface ImageZoomProps {
   src: string;
   id?: string;
   className?: string;
+  classNames?: {
+    wrapper?: string;
+    image?: string;
+  };
   onError?: (error: ErrorEvent) => void;
   errorContent?: React.ReactNode;
+  onZoomChange?: (isZoomed: boolean) => void;
 }
 
 function ImageZoom({
@@ -108,8 +113,10 @@ function ImageZoom({
   src,
   id,
   className,
+  classNames,
   onError,
   errorContent,
+  onZoomChange,
 }: ImageZoomProps): JSX.Element {
   const [isZoomed, setIsZoomed] = useState<boolean>(false);
   const [position, setPosition] = useState<string>("50% 50%");
@@ -147,6 +154,10 @@ function ImageZoom({
     const newPosition = newIsZoomed ? zoomInPosition(e) : "50% 50%";
     if (newPosition) {
       setPosition(newPosition);
+    }
+    
+    if (onZoomChange) {
+      onZoomChange(newIsZoomed);
     }
   };
 
@@ -214,7 +225,8 @@ function ImageZoom({
     isTouchEventRef.current = false;
     setIsZoomed(false);
     setPosition("50% 50%");
-  }, []);
+    onZoomChange?.(false);
+  }, [onZoomChange]);
 
   const figureStyle = useMemo(
     () => ({
@@ -236,6 +248,7 @@ function ImageZoom({
     imgData ? "loaded" : "loading",
     isZoomed ? "zoomed" : "fullView",
     className,
+    classNames?.wrapper,
   ]
     .filter(Boolean)
     .join(" ");
@@ -264,6 +277,7 @@ function ImageZoom({
           id="imageZoom"
           src={imgData}
           alt={alt}
+          className={classNames?.image}
           width={width}
           height={height}
           $isZoomed={isZoomed}


### PR DESCRIPTION
# Feature PR

There are 2 chnages made:

1. Added ability to pass in custom class names for the wrapper and image elements via the `classNames` prop. Allows for greater styling flexibility.
    - `wrapper` for the outer div
    - `image` for the img element

2. Added `onZoomChange` callback prop that is invoked whenever the zoom state changes, providing the new zoomed state as a boolean argument. This allows parent components to respond to zoom state changes. `(isZoomed: boolean) => void`

Thank you for your time.